### PR TITLE
Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,10 @@ install:
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
-
-      conda config --set show_channel_urls true
-      conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
-      
+      conda config --set show_channel_urls true
+      conda install --yes --quiet conda-forge-build-setup
+      source run_conda_forge_build_setup
 
 script:
   - conda build ./recipe

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Package license: BSD 3-Clause
 
 Feedstock license: BSD 3-Clause
 
-Summary: Met Office PP/FieldsFile compression schemes
+Summary: Met Office PP/FieldsFile compression schemes.
 
 
 
@@ -38,7 +38,7 @@ About conda-forge
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the
-conda-forge GitHub organization. The conda-forge organization contains one repository 
+conda-forge GitHub organization. The conda-forge organization contains one repository
 for each of the installable packages. Such a repository is known as a *feedstock*.
 
 A feedstock is made up of a conda recipe (the instructions on what and how to build
@@ -71,7 +71,7 @@ Current build status
 ====================
 
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/libmo_unpack-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/libmo_unpack-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/libmo_unpack-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/libmo_unpack-feedstock) 
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/libmo_unpack-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/libmo_unpack-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/libmo-unpack-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/libmo-unpack-feedstock/branch/master)
 
 Current release info
@@ -92,7 +92,7 @@ install and use.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string). 
+   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
    the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
    back to 0.

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,6 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
-
  - defaults # As we need conda-build
 
 conda-build:
@@ -39,9 +38,8 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
-conda update --yes --all
-conda install --yes conda-build
-conda info
+conda install --yes --quiet conda-forge-build-setup
+source run_conda_forge_build_setup
 
 # Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,7 +13,7 @@ mkdir m4
 sed -i".ac" -e 's/AM_PROG_AR/m4_ifdef([AM_PROG_AR], [AM_PROG_AR])/g' configure.ac
 autoreconf --install
 
-CFLAGS="-O3 -mfpmath=sse -msse"
+CFLAGS="-O3 -mfpmath=sse -msse $CFLAGS"
 
 if [[ $(uname) == Darwin ]]
 then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,11 +5,12 @@ package:
     version: {{ version }}
 
 source:
-    git_url: https://github.com/SciTools/libmo_unpack.git
-    git_rev: v{{ version }}
+    fn: v{{ version }}.tar.gz
+    url: https://github.com/SciTools/libmo_unpack/archive/v{{ version }}.tar.gz
+    sha256: dc64f38ce588c8780d53e91c399cf836588e2afd7d1b7191dc286bf5eca9c75f
 
 build:
-    number: 0
+    number: 1
     skip: True  # [win]
 
 requirements:
@@ -18,18 +19,16 @@ requirements:
         - automake
         - libtool
         - pkg-config
-    run:
-        - libgcc
 
 test:
     commands:
         - test -f ${PREFIX}/lib/libmo_unpack.a  # [not win]
-        - conda inspect linkages -n _test libmo_unpack  # [linux]
+        - conda inspect linkages -n _test libmo_unpack  # [not win]
 
 about:
     home: https://github.com/SciTools/libmo_unpack
     license: BSD 3-Clause
-    summary: Met Office PP/FieldsFile compression schemes
+    summary: 'Met Office PP/FieldsFile compression schemes.'
 
 extra:
     recipe-maintainers:


### PR DESCRIPTION
Updating an old `feedstock`.

PS: There is a 3.1.2 version on GitHub, but the SciTools channel is not build that one as well... I am not sure why but I think we should be in sync to avoid problems.
